### PR TITLE
Avoid division by zero when averaging TPS

### DIFF
--- a/src/main/kotlin/dev/cubxity/tools/stresscraft/cli/StressCraftCLI.kt
+++ b/src/main/kotlin/dev/cubxity/tools/stresscraft/cli/StressCraftCLI.kt
@@ -81,6 +81,9 @@ object StressCraftCLI {
             }
         }
 
+        if (count == 0) {
+            return 0.0
+        }
         return total / count.toDouble()
     }
 }


### PR DESCRIPTION
## Summary
- handle zero-session case when computing average TPS to avoid NaN

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ae172d8fac832cbb1eb69ccad97e4e