### PR TITLE
Add Docker Compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM gradle:7.3.3-jdk17 AS build
+WORKDIR /app
+COPY build.gradle.kts settings.gradle.kts gradle.properties gradlew gradlew.bat ./
+COPY gradle gradle
+COPY src src
+RUN ./gradlew shadowJar --no-daemon
+
+# Runtime stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar stresscraft.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-cp","/app/stresscraft.jar","dev.cubxity.tools.stresscraft.web.StressCraftWebKt"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ Please be aware that attempting to execute this with an external server as a tar
 
 If you're on Velocity, you may also need to set `login-ratelimit` (velocity.toml) to `0`
 
+## Docker Compose
+
+This repository contains a `Dockerfile` and `docker-compose.yml` to run the optional web interface in a container.
+To build and start the service:
+
+```bash
+docker compose up --build
+```
+
+The web UI will be available on [http://localhost:8080](http://localhost:8080).
+
+To run the CLI instead, override the command:
+
+```bash
+docker compose run --rm stresscraft <host> [port]
+```
+
 ## Who needs this?
 
 - Michael
@@ -39,9 +56,9 @@ If you're on Velocity, you may also need to set `login-ratelimit` (velocity.toml
 - [ ] Scripting?
 - [ ] Physics simulation
 - [ ] Random movements
-- [ ] Non-TTY support 
+- [ ] Non-TTY support
 - [ ] Velocity forwarding?
-- [ ] Dockerfile
+- [x] Dockerfile
 - [ ] Helm chart?
 - [ ] GUI Frontend?
 - [ ] Prometheus exporter?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  stresscraft:
+    build: .
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile building the application and starting the web interface
- add docker-compose.yml exposing the web GUI on port 8080
- document Docker usage in README

## Testing
- `./gradlew test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_68af57be3854832cb1ba9c315dad3653